### PR TITLE
Fix HTTPS enforcement documentation and path configuration

### DIFF
--- a/CLOUDFLARE.md
+++ b/CLOUDFLARE.md
@@ -22,7 +22,26 @@ To point `spnss.com` and `www.spnss.com` to your GitHub Pages site:
 
 1.  In the GitHub repository, go to **Settings** > **Pages**.
 2.  Under **Custom domain**, enter `spnss.com`.
-3.  Save and check **Enforce HTTPS**.
+3. Save and check **Enforce HTTPS**. (See [Troubleshooting](#troubleshooting-enforce-https) if this is disabled).
+
+## Troubleshooting: Enforce HTTPS
+
+The GitHub Pages "Enforce HTTPS" checkbox may be disabled if GitHub cannot successfully provision an SSL certificate for your custom domain.
+
+### Why this happens
+When Cloudflare's proxy (Orange Cloud) is active, GitHub's automated certificate provisioning (ACME challenge) might be intercepted by Cloudflare, preventing GitHub from verifying ownership.
+
+### Recommended Solution: Cloudflare "Always Use HTTPS"
+If you are using Cloudflare, the most robust way to enforce HTTPS is through Cloudflare itself:
+1. In the Cloudflare dashboard, go to **SSL/TLS** > **Edge Certificates**.
+2. Enable **Always Use HTTPS**.
+This will redirect all HTTP traffic to HTTPS at the edge, before it even reaches GitHub.
+
+### Alternative Solution: DNS-Only Mode
+If you must enable the toggle in GitHub:
+1. Temporarily change the DNS record proxy status from **Proxied** (Orange Cloud) to **DNS Only** (Grey Cloud) in Cloudflare.
+2. Wait for GitHub to provision the certificate (this can take up to 24 hours, but is usually faster).
+3. Once the "Enforce HTTPS" checkbox is enabled and checked in GitHub, you can re-enable the Cloudflare proxy.
 
 ## 2. Email Forwarding
 

--- a/scripts/verify-deployment.sh
+++ b/scripts/verify-deployment.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Configuration
+DOMAINS=("spnss.com" "www.spnss.com")
+
+echo "Starting deployment verification for: ${DOMAINS[*]}"
+echo "--------------------------------------------------"
+
+for DOMAIN in "${DOMAINS[@]}"; do
+    echo "Checking domain: $DOMAIN"
+    
+    # 1. Check DNS Resolution
+    IP=$(dig +short "$DOMAIN" | tail -n1)
+    if [ -z "$IP" ]; then
+        echo "  [FAIL] DNS resolution failed for $DOMAIN"
+    else
+        echo "  [OK] DNS resolves to: $IP"
+    fi
+
+    # 2. Check HTTP to HTTPS Redirect
+    echo "  Checking HTTP to HTTPS redirect..."
+    RESPONSE=$(curl -sI "http://$DOMAIN")
+    HTTP_CODE=$(echo "$RESPONSE" | grep "HTTP/" | awk '{print $2}')
+    LOCATION=$(echo "$RESPONSE" | grep -i "location:" | awk '{print $2}' | tr -d '\r')
+
+    if [[ "$HTTP_CODE" =~ ^3[0-9][0-9]$ ]]; then
+        if [[ "$LOCATION" == https://* ]]; then
+            echo "  [OK] HTTP $HTTP_CODE redirect to $LOCATION"
+        else
+            echo "  [WARN] HTTP $HTTP_CODE redirect to non-HTTPS location: $LOCATION"
+        fi
+    else
+        echo "  [FAIL] No redirect found (HTTP $HTTP_CODE). Expected 3xx redirect to HTTPS."
+    fi
+
+    # 3. Check for GitHub Headers (if applicable)
+    GH_ID=$(echo "$RESPONSE" | grep -i "x-github-request-id")
+    if [ -n "$GH_ID" ]; then
+        echo "  [INFO] GitHub Request ID found: $GH_ID"
+    fi
+
+    echo ""
+done
+
+echo "Verification complete."

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -14,7 +14,7 @@ const config = {
 			strict: true
 		}),
 		paths: {
-			base: process.env.PUBLIC_BASE_PATH || (process.env.NODE_ENV === 'production' ? '/SPNSS' : '')
+			base: process.env.PUBLIC_BASE_PATH || ''
 		}
 	}
 };


### PR DESCRIPTION
This PR addresses #5 by providing analysis and troubleshooting for HTTPS enforcement on GitHub Pages when using Cloudflare.

Changes:
- Added troubleshooting section to `CLOUDFLARE.md`.
- Created `scripts/verify-deployment.sh` for live site verification.
- Adjusted `svelte.config.js` to remove hardcoded base path for root domain deployment.

Closes #5